### PR TITLE
Organising FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,4 +1,5 @@
 ---
+
 prev: false
 next: false
 
@@ -32,7 +33,7 @@ See [Activation](/quickstart.html#activate-openbubbles).
 
 ::::
 
-:::: details Does the Mac need to stay online?;
+:::: details Does the Mac need to stay online?
 
 No! Once you have setup OpenBubbles, feel free to turn off, discard, or do anything you wish with your Mac. Keep in mind the physical Mac may still be useful for troubleshooting.
 
@@ -132,24 +133,30 @@ This is a known issue and fixes itself after 24 hours.
 
 ## Platform Features FAQ
 
-:::: details  Can OpenBubbles import existing messages? 
+:::: details Can OpenBubbles import existing messages? 
+
+::: warning
+Restoring messages from iCloud is currently in **beta**, you may experience issues.
+:::
+
 * If you have a previous OpenBubbles message backup, yes. To create or restore one, go to Settings -> Backup & Restore -> Messages Backups.
-* If you do not have an OpenBubbles message backup, not at this time. OpenBubbles cannot backfill messages from iCloud.
+* To restore messages stores in iCloud, go to Settings -> Profile -> Messages in iCloud (BETA).
 
 ::::
 
-:::: details  Does OpenBubbles work with FindMy?
+:::: details Does OpenBubbles work with FindMy?
 
-Yes! Access the Find My page from the top 3 dots on the main screen. If no Find My option appears, you need to re-log in. Choose "Change Hardware" in settings.
-* AirTags are not supported
-* Sharing live location with other users is not supported
+Yes! Access the Find My page from the top 3 dots on the main screen -> Maps. If this option doesn't appear, you need to re-log in. Choose "Change Hardware" in settings.
+
+* AirTags are supported.
+* Sharing live location with other users is **not** supported.
 * Receiving shared locations through Find My and iMessage is supported
 * Tracking other devices is supported
 
 ::::
 
-:::: details  Can I create shared albums?
-No, at this time only receiving is supported. However, you can contribute media to shared albums you are invited to.
+::: details Can I create shared albums?
+No, at this time only receiving is supported. However, you can contribute media to shared albums you are invited to. You can access this from the top 3 dots on the main screen -> Shared Albums.
 
 ::::
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,37 +1,50 @@
+---
+prev: false
+next: false
+
+---
 
 # Frequently Asked Questions
 
-:::: details  What is "Hardware Info"?
+## Hardware FAQ
 
-See [activation](/quickstart#what-is-hardware-info)
+:::: details Is OpenBubbles safe to use?
 
-::::
+Everything happens locally, on your phone or computer. Anything that happens is strictly between you and Apple. An immense effort has been made to ensure a reliable and safe experience.
 
-:::: details  How can I obtain hardware info?
+That being said, iMessage is a complex and changing system, and every situation cannot be predicted. Most issues will only affect OpenBubbles, and will not affect other devices or your account. In extremely rare cases, your account may be temporarily (day or two) or permanently blocked. In permanent cases, a call with Apple support will usually lift the block.
 
-See [activation](/quickstart.html#activate-openbubbles)
-
-::::
-
-:::: details  Can OpenBubbles import existing messages? 
-* If you have a previous OpenBubbles message backup, yes. To create or restore one, go to Settings -> Backup & Restore -> Messages Backups.
-* If you do not have an OpenBubbles message backup, not at this time. OpenBubbles cannot backfill messages from iCloud.
+::: warning
+You are responsible for who you share your hardware identifiers with. If someone uses your hardware identifiers to send mass spam, your device _**will**_ be blocked, and you will only have yourself to blame. If you share one device with over 20 users, you may experience issues.
+:::
 
 ::::
 
-:::: details  What if I do not have access to a Mac?
+:::: details What does hardware info mean?
 
-If you don't have access to a Mac, ask a friend to share their code with you. They can share it from the hardware info app on the Mac, or from settings inside OpenBubbles. One Mac can be used by up to 20 users (unlimited logins).
+See [Activation -> What is hardware info?](/quickstart.html#what-is-hardware-info).
 
 ::::
 
-:::: details  Does the Mac need to stay online?;
+:::: details How can I obtain hardware info?
+
+See [Activation](/quickstart.html#activate-openbubbles).
+
+::::
+
+:::: details Does the Mac need to stay online?;
 
 No! Once you have setup OpenBubbles, feel free to turn off, discard, or do anything you wish with your Mac. Keep in mind the physical Mac may still be useful for troubleshooting.
 
 ::::
 
-:::: details  What does "prevent sharing" do?
+:::: details What if I do not have access to a Mac?
+
+If you don't have access to a Mac, ask a friend to share their code with you. They can share it from the hardware info app on the Mac, or from settings inside OpenBubbles. See [Activation -> Option B](/quickstart.html#step-2-activate-openbubbles)
+
+::::
+
+:::: details What does "prevent sharing" do?
 
 * Enabling "prevent sharing" applies a few restrictions to generated codes:
 * Can only be used once (text codes only)
@@ -40,21 +53,32 @@ No! Once you have setup OpenBubbles, feel free to turn off, discard, or do anyth
 
 ::::
 
-:::: details  Is OpenBubbles safe to use?&#x20;
+:::: details Will the Mac I use have access to my account?
+No. OpenBubbles impersonates the Mac, and the Mac is not even aware of the login and doesn't have any of the associated keys. If you see the Mac logged in on your Apple ID page, you are seeing OpenBubbles.
 
-Everything happens locally, on your phone. Anything that happens is strictly between you and Apple. An immense effort has been made to ensure a reliable and safe experience. That being said, iMessage is a complex and changing system, and every situation cannot be predicted. Most issues will only affect OpenBubbles, and will not affect other devices or your account. In extremely rare cases, your account may be temporarily (day or two) or permanently blocked. In permanent cases, a call with Apple support will usually lift the block.
-::: warning
-You are responsible for who you share your hardware identifiers with. If someone uses your hardware identifiers to send mass spam, your device _**will**_ be blocked, and you will only have yourself to blame. If you share one device with over 20 users, you may experience issues.
+::::
+
+:::: details Can I use a VM with OpenBubbles? <Badge type="danger" text="Caution" />
+::: danger
+**Do not use data from a virtual machine.** **No**, it doesn't matter that iMessage works in the VM. **No**, your generated data is not "special" or "approved". Apple *knows* your hardware info is phony and any success you on the VM get is Apple being nice. Register another time with OB and there is a decent chance your account will be banned. You have been warned.
 :::
 
 ::::
 
-:::: details  I am having issues logging into my Apple Account
+:::: details Can I register my phone number with OpenBubbles? <Badge type="danger" text="Caution" />
+
+Activation with a phone number is possible but **not recommended for new users** and requires significant setup. See [Activation -> Option C](/quickstart.html#step-2-activate-openbubbles).
+
+::::
+
+## Activation FAQ
+
+:::: details I am having issues logging into my Apple Account
 To potentially resolve this issue, go to https://account.apple.com/, and delete any duplicate devices and try again.
 
 ::::
 
-:::: details  Disable Foreground Service Notification
+:::: details Disable Foreground Service Notification
 This notification is not needed for OpenBubbles to function.
 
 To disable, either:
@@ -71,21 +95,46 @@ All the methods should end on a page like this:
 
 ::::
 
-:::: details  Can I use a VM with OpenBubbles?
-::: danger
-**Do not use data from a virtual machine.** **No**, it doesn't matter that iMessage works in the VM. **No**, your generated data is not "special" or "approved". Apple *knows* your hardware info is phony and any success you on the VM get is Apple being nice. Register another time with OB and there is a decent chance your account will be banned. Don't say I didn't warn you.
-:::
+:::: details Why are contacts I know are using iMessage showing up green?
+
+This means you are throttled by Apple. Wait a few hours/days and try again.
+* If you recently registered, this can be normal.
+* If you have texted many people (group chat or otherwise) you may have to wait a few days or weeks for Apple to raise your limit.
 
 ::::
 
-:::: details  Will the Mac I use have access to my account?
-No. OpenBubbles impersonates the Mac, and the Mac is not even aware of the login and doesn't have any of the associated keys. If you see the Mac logged in on your Apple ID page, you are seeing OpenBubbles.
+:::: details I see "Verification Failed" under some messages. What does this mean?
+This indicates OpenBubbles could not verify the identity of the sender when the message was received. This can be caused for a few reasons:
+* You had a poor connection at the time and Apple's keyserver could not be contacted
+* You are being rate-limited by Apple
+* \[Highly unlikely\] An attacker has compromised APS (but not the keyserver) and is attempting to send a message from an identity that isn't theirs.
 
 ::::
 
-:::: details  Can I register my phone number with OpenBubbles?
+:::: details Why can't I send or receive messages?
 
-If you have an iPhone running the relay app, yes. The phone must stay online at all times. Enter the relay code on the hardware identifier screen, and you will be prompted to register your number. Please refer to the [Phone Number Registration](pnr) page for more information.
+* Running clear identity cache (Go to Settings -> Developer Tools) - This may help with sending messages.
+* Make sure iMessage and Facetime is disabled and you are logged out of iCloud if you are using an iPhone.
+* You are deregistered - Check your registration status and renewal time in your profile settings and check your registration method and try again.
+* Advanced Data Protection is enabled - Disable this option
+* Contact Key Verification is enabled - Disable this option
+* Your Apple Account/Hardware has been throttled/banned/blocked by Apple - Visit this [site](https://rentry.org/applebans) to learn more. You may need to create a new account.
+
+Contact us on [Discord](https://discord.gg/98fWS4AQqN) if issues persist.
+
+::::
+
+:::: details Why can't I see my messages sent on OpenBubbles on other Apple devices, even though my Apple Account is linked?
+
+This is a known issue and fixes itself after 24 hours.
+
+::::
+
+## Platform Features FAQ
+
+:::: details  Can OpenBubbles import existing messages? 
+* If you have a previous OpenBubbles message backup, yes. To create or restore one, go to Settings -> Backup & Restore -> Messages Backups.
+* If you do not have an OpenBubbles message backup, not at this time. OpenBubbles cannot backfill messages from iCloud.
 
 ::::
 
@@ -104,43 +153,8 @@ No, at this time only receiving is supported. However, you can contribute media 
 
 ::::
 
-:::: details  Does OpenBubbles work with FaceTime?
+:::: details Does OpenBubbles work with FaceTime?
 
 Yes! Incoming FaceTime calls should ring automatically. You can see recent FaceTime calls or place one yourself by opening the FaceTime under the three-dot menu.
-
-::::
-
-:::: details  Why are contacts I know are using iMessage showing up green?
-
-This means you are throttled by Apple. Wait a few hours/days and try again.
-* If you recently registered, this can be normal.
-* If you have texted many people (group chat or otherwise) you may have to wait a few days or weeks for Apple to raise your limit.
-
-::::
-
-:::: details  I see "Verification Failed" under some messages. What does this mean?
-This indicates OpenBubbles could not verify the identity of the sender when the message was received. This can be caused for a few reasons:
-* You had a poor connection at the time and Apple's keyserver could not be contacted
-* You are being rate-limited by Apple
-* \[Highly unlikely\] An attacker has compromised APS (but not the keyserver) and is attempting to send a message from an identity that isn't theirs.
-
-::::
-
-:::: details  Why can't I send or receive messages?
-
-* Running clear identity cache (Go to Settings -> Developer Tools) - This may help with sending messages.
-* Make sure iMessage and Facetime is disabled and you are logged out of iCloud if you are using an iPhone.
-* You are deregistered - Check your registration status and renewal time in your profile settings and check your registration method and try again.
-* Advanced Data Protection is enabled - Disable this option
-* Contact Key Verification is enabled - Disable this option
-* Your Apple Account/Hardware has been throttled/banned/blocked by Apple - Visit this [site](https://rentry.org/applebans) to learn more. You may need to create a new account.
-
-Contact us on [Discord](https://discord.gg/98fWS4AQqN) if issues persist.
-
-::::
-
-:::: details  Why can't I see my messages sent on OpenBubbles on other Apple devices, even though my Apple Account is linked?
-
-This is a known issue and fixes itself after 24 hours.
 
 ::::

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,8 +3,7 @@
 
 ## What is "Hardware Info"?&#x20;
 
-During iMessage activation, your machine's hardware identifiers (serial number, board ID, model, etc.) are sent to Apple for validation. 
-OpenBubbles requires valid machine identifiers to send to Apple during activation. OpenBubbles refers to this data as "hardware info".
+See [activation](/quickstart.html#activate-openbubbles)
 
 ## How can I obtain hardware info?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,7 +3,7 @@
 
 ## What is "Hardware Info"?&#x20;
 
-See [activation](/quickstart.html#activate-openbubbles)
+See [activation](/quickstart#what-is-hardware-info)
 
 ## How can I obtain hardware info?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,44 +1,60 @@
 
 # Frequently Asked Questions
 
-## What is "Hardware Info"?&#x20;
+:::: details  What is "Hardware Info"?
 
 See [activation](/quickstart#what-is-hardware-info)
 
-## How can I obtain hardware info?
+::::
+
+:::: details  How can I obtain hardware info?
 
 See [activation](/quickstart.html#activate-openbubbles)
 
-## Can OpenBubbles import existing messages? 
+::::
+
+:::: details  Can OpenBubbles import existing messages? 
 * If you have a previous OpenBubbles message backup, yes. To create or restore one, go to Settings -> Backup & Restore -> Messages Backups.
 * If you do not have an OpenBubbles message backup, not at this time. OpenBubbles cannot backfill messages from iCloud.
 
-## What if I do not have access to a Mac?
+::::
+
+:::: details  What if I do not have access to a Mac?
 
 If you don't have access to a Mac, ask a friend to share their code with you. They can share it from the hardware info app on the Mac, or from settings inside OpenBubbles. One Mac can be used by up to 20 users (unlimited logins).
 
-## Does the Mac need to stay online?&#x20;
+::::
+
+:::: details  Does the Mac need to stay online?;
 
 No! Once you have setup OpenBubbles, feel free to turn off, discard, or do anything you wish with your Mac. Keep in mind the physical Mac may still be useful for troubleshooting.
 
-## What does "prevent sharing" do?
+::::
+
+:::: details  What does "prevent sharing" do?
 
 * Enabling "prevent sharing" applies a few restrictions to generated codes:
 * Can only be used once (text codes only)
 * Expire after 48 hours (text codes only)
 * Cannot be shared to other users after completing setup.
 
-## Is OpenBubbles safe to use?&#x20;
+::::
+
+:::: details  Is OpenBubbles safe to use?&#x20;
 
 Everything happens locally, on your phone. Anything that happens is strictly between you and Apple. An immense effort has been made to ensure a reliable and safe experience. That being said, iMessage is a complex and changing system, and every situation cannot be predicted. Most issues will only affect OpenBubbles, and will not affect other devices or your account. In extremely rare cases, your account may be temporarily (day or two) or permanently blocked. In permanent cases, a call with Apple support will usually lift the block.
 ::: warning
 You are responsible for who you share your hardware identifiers with. If someone uses your hardware identifiers to send mass spam, your device _**will**_ be blocked, and you will only have yourself to blame. If you share one device with over 20 users, you may experience issues.
 :::
-## I am having issues logging into my Apple Account
+
+::::
+
+:::: details  I am having issues logging into my Apple Account
 To potentially resolve this issue, go to https://account.apple.com/, and delete any duplicate devices and try again.
 
+::::
 
-## Disable Foreground Service Notification
+:::: details  Disable Foreground Service Notification
 This notification is not needed for OpenBubbles to function.
 
 To disable, either:
@@ -53,19 +69,27 @@ All the methods should end on a page like this:
 
 ![Foreground service](/foreground.png)
 
-## Can I use a VM with OpenBubbles?
+::::
+
+:::: details  Can I use a VM with OpenBubbles?
 ::: danger
 **Do not use data from a virtual machine.** **No**, it doesn't matter that iMessage works in the VM. **No**, your generated data is not "special" or "approved". Apple *knows* your hardware info is phony and any success you on the VM get is Apple being nice. Register another time with OB and there is a decent chance your account will be banned. Don't say I didn't warn you.
 :::
 
-## Will the Mac I use have access to my account?
+::::
+
+:::: details  Will the Mac I use have access to my account?
 No. OpenBubbles impersonates the Mac, and the Mac is not even aware of the login and doesn't have any of the associated keys. If you see the Mac logged in on your Apple ID page, you are seeing OpenBubbles.
 
-## Can I register my phone number with OpenBubbles?
+::::
+
+:::: details  Can I register my phone number with OpenBubbles?
 
 If you have an iPhone running the relay app, yes. The phone must stay online at all times. Enter the relay code on the hardware identifier screen, and you will be prompted to register your number. Please refer to the [Phone Number Registration](pnr) page for more information.
 
-## Does OpenBubbles work with FindMy?
+::::
+
+:::: details  Does OpenBubbles work with FindMy?
 
 Yes! Access the Find My page from the top 3 dots on the main screen. If no Find My option appears, you need to re-log in. Choose "Change Hardware" in settings.
 * AirTags are not supported
@@ -73,26 +97,36 @@ Yes! Access the Find My page from the top 3 dots on the main screen. If no Find 
 * Receiving shared locations through Find My and iMessage is supported
 * Tracking other devices is supported
 
-## Can I create shared albums?
+::::
+
+:::: details  Can I create shared albums?
 No, at this time only receiving is supported. However, you can contribute media to shared albums you are invited to.
 
-## Does OpenBubbles work with FaceTime?
+::::
+
+:::: details  Does OpenBubbles work with FaceTime?
 
 Yes! Incoming FaceTime calls should ring automatically. You can see recent FaceTime calls or place one yourself by opening the FaceTime under the three-dot menu.
 
-## Why are contacts I know are using iMessage showing up green?
+::::
+
+:::: details  Why are contacts I know are using iMessage showing up green?
 
 This means you are throttled by Apple. Wait a few hours/days and try again.
 * If you recently registered, this can be normal.
 * If you have texted many people (group chat or otherwise) you may have to wait a few days or weeks for Apple to raise your limit.
 
-## I see "Verification Failed" under some messages. What does this mean?
+::::
+
+:::: details  I see "Verification Failed" under some messages. What does this mean?
 This indicates OpenBubbles could not verify the identity of the sender when the message was received. This can be caused for a few reasons:
 * You had a poor connection at the time and Apple's keyserver could not be contacted
 * You are being rate-limited by Apple
 * \[Highly unlikely\] An attacker has compromised APS (but not the keyserver) and is attempting to send a message from an identity that isn't theirs.
 
-## Why can't I send or receive messages?
+::::
+
+:::: details  Why can't I send or receive messages?
 
 * Running clear identity cache (Go to Settings -> Developer Tools) - This may help with sending messages.
 * Make sure iMessage and Facetime is disabled and you are logged out of iCloud if you are using an iPhone.
@@ -103,6 +137,10 @@ This indicates OpenBubbles could not verify the identity of the sender when the 
 
 Contact us on [Discord](https://discord.gg/98fWS4AQqN) if issues persist.
 
-## Why can't I see my messages sent on OpenBubbles on other Apple devices, even though my Apple Account is linked?
+::::
+
+:::: details  Why can't I see my messages sent on OpenBubbles on other Apple devices, even though my Apple Account is linked?
 
 This is a known issue and fixes itself after 24 hours.
+
+::::

--- a/quickstart.md
+++ b/quickstart.md
@@ -46,7 +46,8 @@ Setup with a Mac is the most easiest, **and recommended**, however a Mac install
 
 :::: details Option A. With a Mac <Badge type="tip" text="Recommended"/>
 
-On a Mac, [download and run the QR code generator](https://github.com/OpenBubbles/Mac-Hardware-Info/releases/latest/download/Mac.Hardware.Info.zip). Scan the QR code or copy the activation code to your other device. The Mac does not need to stay online. It will not have access to your Apple Account.
+1. On a Mac, [download and run the QR code generator](https://github.com/OpenBubbles/Mac-Hardware-Info/releases/latest/download/Mac.Hardware.Info.zip).
+2. Scan the QR code or copy the activation code to your other device. The Mac does not need to stay online. It will not have access to your Apple Account.
 
 ::: info
 Your Mac can be shared with **up to 20 friends** with the App. However, it cannot register your phone number.
@@ -55,9 +56,10 @@ Your Mac can be shared with **up to 20 friends** with the App. However, it canno
 ::::
 
 :::: details Option B. From another OpenBubbles app (Mac hardware info only) 
-Open OpenBubbles, then go to Settings -> Your Mac.
 
-Scan the QR code on another device or share an activation link with your friend.
+1. Open OpenBubbles, then go to Settings -> Your Mac.
+
+2. Scan the QR code on another device or share an activation link with your friend.
 
 If no code shows, the owner of the Mac has chosen to prevent further sharing.
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -75,3 +75,10 @@ Using an iPhone is **not recommended for new users**. It only works on certain i
 ::::
 
 See [Phone Number Registration](/docs/pnr)
+
+## Getting help
+
+If you experience an issue while following this guide, there are multiple ways you can get help.
+* If you have any questions that haven't been answered on this page, their answers might be in the [FAQ](/docs/faq).
+* If you experience an issue while following this guide, you can check the [Troubleshooting](/docs/troubleshooting.md) page for a solution.
+* If the resources we've provided here aren't helping, you can get support over at the [OpenBubbles Discord Server](https://discord.com/invite/MWxPgEp).

--- a/quickstart.md
+++ b/quickstart.md
@@ -22,6 +22,12 @@ outline: false
 We recommend reading this entire guide thoroughly before proceeding.
 :::
 
+## What is Openbubbles?
+
+**OpenBubbles** is an open-source and cross-platform ecosystem of apps aimed to bring Apple platform services (including iMessage and FaceTime) to Android, Windows and Linux.
+
+OpenBubbles works by using the "hardware info" of an Apple Mac or iPhone to register with Apple, allowing the use of their services.
+
 ## What is hardware info?
 
 During activation, your machine's hardware identifiers (serial number, board ID, model, etc.) are sent to Apple for validation.

--- a/quickstart.md
+++ b/quickstart.md
@@ -22,6 +22,11 @@ outline: false
 Apple **requires** hardware info from genuine Apple hardware to use iMessage. [Join the waitlist](/#hosted-waitlist) for a ready-to-go hosted solution. OpenBubbles works **best** with a Mac.
 :::
 
+## What is "Hardware Info"?&#x20;
+
+During iMessage activation, your machine's hardware identifiers (serial number, board ID, model, etc.) are sent to Apple for validation. 
+OpenBubbles requires valid machine identifiers to send to Apple during activation. OpenBubbles refers to this data as "hardware info".
+
 ## Step 1. Install OpenBubbles
 
 Install OpenBubbles on your preferred device:

--- a/quickstart.md
+++ b/quickstart.md
@@ -18,6 +18,10 @@ outline: false
 
 # Self-host Guide
 
+::: tip 
+We recommend reading this entire guide thoroughly before proceeding.
+:::
+
 ## What is hardware info?
 
 During activation, your machine's hardware identifiers (serial number, board ID, model, etc.) are sent to Apple for validation.

--- a/quickstart.md
+++ b/quickstart.md
@@ -22,14 +22,17 @@ outline: false
 Apple **requires** hardware info from genuine Apple hardware to use iMessage. [Join the waitlist](/#hosted-waitlist) for a ready-to-go hosted solution. OpenBubbles works **best** with a Mac.
 :::
 
-## Install OpenBubbles
+## Step 1. Install OpenBubbles
+
+Install OpenBubbles on your preferred device:
+
 <a href="https://play.google.com/store/apps/details?id=com.openbubbles.messaging"><img src="/google_play_badge.png" class="getbtn" /></a>
 <a href="https://apps.microsoft.com/store/detail/9PJMSNSQD0FV"><img src="/get-ms.svg" class="getbtn" /></a>
 <a href="https://flathub.org/apps/app.openbubbles.OpenBubbles"><img src="/badge-flathub.svg" class="getbtn" /></a>
 
 
 
-## Activate OpenBubbles
+## Step 2. Activate OpenBubbles
 
 ### With a Mac
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -44,7 +44,7 @@ OpenBubbles can be activated by using the hardware info of a Mac, an iPhone or f
 
 Setup with a Mac is the most easiest, **and recommended**, however a Mac install will only allow for platform services to be registered with your iCloud email. To register a phone number, an iPhone is required.
 
-### With a Mac
+:::: details With a Mac
 
 On a Mac, [download and run the QR code generator](https://github.com/OpenBubbles/Mac-Hardware-Info/releases/latest/download/Mac.Hardware.Info.zip). Scan the QR code or copy the activation code to your other device. The Mac does not need to stay online. It will not have access to your Apple Account.
 
@@ -52,19 +52,22 @@ On a Mac, [download and run the QR code generator](https://github.com/OpenBubble
 Your Mac can be shared with **up to 20 friends** with the App. However, it cannot register your phone number.
 :::
 
-### From another device (Mac Hardware only)
+::::
+
+:::: details From another device (Mac Hardware only)
 Open OpenBubbles, then go to Settings -> Your Mac.
 
 Scan the QR code on another device or share an activation link with your friend.
 
 If no code shows, the owner of the Mac has chosen to prevent further sharing.
 
-### With an iPhone <Badge type="danger" text="caution" />
+::::
+
+:::: details With an iPhone <Badge type="danger" text="caution" />
 ::: danger
 Using an iPhone is **not recommended for new users**. It only works on certain iOS versions and models, and requires significant setup. The iPhone must stay online at all times, and can only be used by one user. However, Android phone numbers **can** be registered with an iPhone (without a second SIM).
 :::
 
+::::
+
 See [Phone Number Registration](/docs/pnr)
-
-
-

--- a/quickstart.md
+++ b/quickstart.md
@@ -16,7 +16,7 @@ outline: false
     }
 </style>
 
-# Self-host quickstart
+# Self-host Guide
 
 ::: tip
 Apple **requires** hardware info from genuine Apple hardware to use iMessage. [Join the waitlist](/#hosted-waitlist) for a ready-to-go hosted solution. OpenBubbles works **best** with a Mac.

--- a/quickstart.md
+++ b/quickstart.md
@@ -18,14 +18,13 @@ outline: false
 
 # Self-host Guide
 
-::: tip
-Apple **requires** hardware info from genuine Apple hardware to use iMessage. [Join the waitlist](/#hosted-waitlist) for a ready-to-go hosted solution. OpenBubbles works **best** with a Mac.
-:::
+## What is hardware info?
 
-## What is "Hardware Info"?&#x20;
+During activation, your machine's hardware identifiers (serial number, board ID, model, etc.) are sent to Apple for validation.
 
-During iMessage activation, your machine's hardware identifiers (serial number, board ID, model, etc.) are sent to Apple for validation. 
-OpenBubbles requires valid machine identifiers to send to Apple during activation. OpenBubbles refers to this data as "hardware info".
+OpenBubbles requires valid machine identifiers to send to Apple during activation. OpenBubbles refers to this data as **"hardware info"**.
+
+A self-hosted setup of Openbubbles requires hardware info from genuine Apple hardware. For a read-to-go paid solution hosted by Openbubbles, [join the waitlist](/#hosted-waitlist).
 
 ## Step 1. Install OpenBubbles
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -78,9 +78,9 @@ The hardware info of a single Mac can be shared with **up to 20 friends** with t
 Using an iPhone is **not recommended for new users**. It only works on certain iOS versions and models, and requires significant setup. The iPhone must stay online at all times, and can only be used by one user. However, if you wish to use iMessage with a phone number an iPhone, this method is required.
 :::
 
-::::
-
 See [Phone Number Registration](/docs/pnr)
+
+::::
 
 ## Getting help
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -44,7 +44,7 @@ OpenBubbles can be activated by using the hardware info of a Mac, an iPhone or f
 
 Setup with a Mac is the most easiest, **and recommended**, however a Mac install will only allow for platform services to be registered with your iCloud email. To register a phone number, an iPhone is required.
 
-:::: details With a Mac
+:::: details Option A. With a Mac <Badge type="tip" text="Recommended"/>
 
 On a Mac, [download and run the QR code generator](https://github.com/OpenBubbles/Mac-Hardware-Info/releases/latest/download/Mac.Hardware.Info.zip). Scan the QR code or copy the activation code to your other device. The Mac does not need to stay online. It will not have access to your Apple Account.
 
@@ -54,7 +54,7 @@ Your Mac can be shared with **up to 20 friends** with the App. However, it canno
 
 ::::
 
-:::: details From another device (Mac Hardware only)
+:::: details Option B. From another OpenBubbles app (Mac hardware info only) 
 Open OpenBubbles, then go to Settings -> Your Mac.
 
 Scan the QR code on another device or share an activation link with your friend.
@@ -63,7 +63,7 @@ If no code shows, the owner of the Mac has chosen to prevent further sharing.
 
 ::::
 
-:::: details With an iPhone <Badge type="danger" text="caution" />
+:::: details Option C. With an iPhone <Badge type="danger" text="Caution" />
 ::: danger
 Using an iPhone is **not recommended for new users**. It only works on certain iOS versions and models, and requires significant setup. The iPhone must stay online at all times, and can only be used by one user. However, Android phone numbers **can** be registered with an iPhone (without a second SIM).
 :::

--- a/quickstart.md
+++ b/quickstart.md
@@ -75,7 +75,7 @@ The hardware info of a single Mac can be shared with **up to 20 friends** with t
 
 :::: details Option C. With an iPhone <Badge type="danger" text="Caution" />
 ::: danger
-Using an iPhone is **not recommended for new users**. It only works on certain iOS versions and models, and requires significant setup. The iPhone must stay online at all times, and can only be used by one user. However, Android phone numbers **can** be registered with an iPhone (without a second SIM).
+Using an iPhone is **not recommended for new users**. It only works on certain iOS versions and models, and requires significant setup. The iPhone must stay online at all times, and can only be used by one user. However, if you wish to use iMessage with a phone number an iPhone, this method is required.
 :::
 
 ::::

--- a/quickstart.md
+++ b/quickstart.md
@@ -38,9 +38,11 @@ Install OpenBubbles on your preferred device:
 <a href="https://apps.microsoft.com/store/detail/9PJMSNSQD0FV"><img src="/get-ms.svg" class="getbtn" /></a>
 <a href="https://flathub.org/apps/app.openbubbles.OpenBubbles"><img src="/badge-flathub.svg" class="getbtn" /></a>
 
-
-
 ## Step 2. Activate OpenBubbles
+
+OpenBubbles can be activated by using the hardware info of a Mac, an iPhone or from another OpenBubbles user who has activated OpenBubbles using Mac hardware info. 
+
+Setup with a Mac is the most easiest, **and recommended**, however a Mac install will only allow for platform services to be registered with your iCloud email. To register a phone number, an iPhone is required.
 
 ### With a Mac
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -51,13 +51,13 @@ Setup with a Mac is the most easiest, **and recommended**, however a Mac install
 2. Open your other device you installed OpenBubbles earlier. 
 3. Scan the QR code or copy the activation code to your other device. The Mac does not need to stay online. It will not have access to your Apple Account.
 
-::: info
-Your Mac can be shared with **up to 20 friends** with the App. However, it cannot register your phone number.
-:::
-
 ::::
 
 :::: details Option B. From another OpenBubbles app (Mac hardware info only) 
+
+::: warning
+You are responsible for who you share your hardware identifiers with. If someone uses your hardware identifiers to send mass spam, your device _**will**_ be blocked. If you share one device with over 20 users, you may experience issues.
+:::
 
 The hardware info of a single Mac can be shared with **up to 20 friends** with the App. This method assumes you know someone who has already setup a self-hosted OpenBubbles instance, and is willing to share their Mac hardware info.
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -46,8 +46,10 @@ Setup with a Mac is the most easiest, **and recommended**, however a Mac install
 
 :::: details Option A. With a Mac <Badge type="tip" text="Recommended"/>
 
-1. On a Mac, [download and run the QR code generator](https://github.com/OpenBubbles/Mac-Hardware-Info/releases/latest/download/Mac.Hardware.Info.zip).
-2. Scan the QR code or copy the activation code to your other device. The Mac does not need to stay online. It will not have access to your Apple Account.
+1. On a Mac, [download and run the QR code generator program](https://github.com/OpenBubbles/Mac-Hardware-Info/releases/latest/download/Mac.Hardware.Info.zip).
+    * If you wish to limit your Mac hardware info to one iCloud account, tick "Prevent Sharing".
+2. Open your other device you installed OpenBubbles earlier. 
+3. Scan the QR code or copy the activation code to your other device. The Mac does not need to stay online. It will not have access to your Apple Account.
 
 ::: info
 Your Mac can be shared with **up to 20 friends** with the App. However, it cannot register your phone number.
@@ -57,11 +59,11 @@ Your Mac can be shared with **up to 20 friends** with the App. However, it canno
 
 :::: details Option B. From another OpenBubbles app (Mac hardware info only) 
 
-1. Open OpenBubbles, then go to Settings -> Your Mac.
+The hardware info of a single Mac can be shared with **up to 20 friends** with the App. This method assumes you know someone who has already setup a self-hosted OpenBubbles instance, and is willing to share their Mac hardware info.
 
-2. Scan the QR code on another device or share an activation link with your friend.
-
-If no code shows, the owner of the Mac has chosen to prevent further sharing.
+1. On the other device, OpenBubbles and go to: Settings -> Your Mac.
+2. Scan the QR code on another device with the OpenBubbles or share an activation link with your friend.
+* If no code shows, the owner of the Mac has chosen to prevent further sharing during setup.
 
 ::::
 


### PR DESCRIPTION
I found the FAQ to have very useful information, but was a lot of text on the screen all at once. These commits:

- Collapses each question into details boxes
- Adds subheadings based on type of question
- Reorders questions into subheadings
- Adds some more info to a few items

Love to know what you think! :)
