### PR TITLE
Phone Registration Rewrite

### DIFF
--- a/docs/pnr.md
+++ b/docs/pnr.md
@@ -26,7 +26,8 @@ Sim swapping is a method which involves using an iPhone to register a number, an
 [All These BlueBubbles | Sim Swapping Guide](https://guide.atbluebubbles.com/ )
 
 ### Option B. Relay App
-Keep the device on at all times and connected to Wi-Fi in order to keep your number registered. 
+This method installs a Relay App to communicate the iPhone's hardware info to OpenBubbles. Apple limits the installation of apps to it's App Store, this guide will circumvent this, this is called **sideloading**.
+
 While not required, leaving the display on may improve reliability.
 
 :::: details Method 1 - iOS 14.0 - iOS 17.0

--- a/docs/pnr.md
+++ b/docs/pnr.md
@@ -1,5 +1,10 @@
 
 # Phone Number Registration <Badge type="danger" text="Caution"/>
+
+::: tip 
+Using an iPhone requires significant setup. We recommend reading this entire guide thoroughly before proceeding.
+:::
+
 ::: warning
 
 The following guide contains links to third-party websites that are not affiliated with OpenBubbles and their contents can change at any time. Use at your own risk.
@@ -7,9 +12,7 @@ The following guide contains links to third-party websites that are not affiliat
 
 This guide will explain how to get your phone number working on iMessage.
 
-Phone Number Registration may not be as reliable as Mac registration, and different carriers may not play nicely. OpenBubbles operates **BEST** with Mac hardware info.
-
-We recommend reading this guide thoroughly at least once before beginning any setup.
+Phone Number Registration may not be as reliable as Mac registration, and different carriers may not play nicely. OpenBubbles operates **best** with Mac hardware info.
 
 ## Key Information 
 

--- a/docs/pnr.md
+++ b/docs/pnr.md
@@ -76,6 +76,7 @@ This method can be unreliable and your milage may vary.
 
 See [All These BlueBubbles | Sim Swapping Guide](https://guide.atbluebubbles.com/ )
 
-###
-**Credits** : [pypush, jjtech, Alfie,](https://discord.com/channels/1130633272595066880/1135636248019615874/1231003645529817139) [BlueBubbles Team](https://github.com/orgs/BlueBubblesApp/people), [danip](https://discord.com/channels/1130633272595066880/1135636248019615874/1231003645529817139), [cjocollin](https://www.reddit.com/r/BlueBubbles/comments/1938ock/stop_using_old_methods_heres_a_new_one/) and [Copperboy100](https://github.com/TaeHagen)
+
+### Credits
+[pypush, jjtech, Alfie,](https://discord.com/channels/1130633272595066880/1135636248019615874/1231003645529817139) [BlueBubbles Team](https://github.com/orgs/BlueBubblesApp/people), [danip](https://discord.com/channels/1130633272595066880/1135636248019615874/1231003645529817139), [cjocollin](https://www.reddit.com/r/BlueBubbles/comments/1938ock/stop_using_old_methods_heres_a_new_one/) and [Copperboy100](https://github.com/TaeHagen)
 ###

--- a/docs/pnr.md
+++ b/docs/pnr.md
@@ -11,6 +11,10 @@ Phone Number Registration may not be as reliable as Mac registration, and differ
 
 We recommend reading this guide thoroughly at least once before beginning any setup.
 
+## Key Information 
+
+Maintaining registration requires the iPhone and relay to stay online. Apple can force a re-registeration at any time, therefore **your iPhone must be online at all times** once setup has been completed. If you're iPhone or relay is offline when Apple re-registers your phone number may be deregistered.
+
 ## Step 1. Pre-Setup
 Make sure iMessage andFacetime is disabled on your iPhone. You also need to disable Advanced Data Protection and Contact Key Verification.
 

--- a/docs/pnr.md
+++ b/docs/pnr.md
@@ -20,12 +20,9 @@ Make sure iMessage and Facetime is disabled on your iPhone. You also need to dis
 
 ## Step 2. Activation
 
-### Option A. Sim / eSim Swaping Methods
+There are two methods to setup phone number registration:
 
-Sim swapping is a method which involves using an iPhone to register a number, and then using OpenBubbles normally with Mac hardware data. You can follow the same guides used for BlueBubbles. However, this method can be even more unreliable than OB.
-[All These BlueBubbles | Sim Swapping Guide](https://guide.atbluebubbles.com/ )
-
-### Option B. Relay App
+### Option A. Relay App <Badge type="tip" text="Recommended" />
 This method installs a Relay App to communicate the iPhone's hardware info to OpenBubbles. Apple limits the installation of apps to it's App Store, this guide will circumvent this, this is called **sideloading**.
 
 While not required, leaving the display on may improve reliability.
@@ -65,6 +62,11 @@ If you are on older iOS versions (10 - 14) and jailbroken follow these steps:
 5. Input the code from the relay app in OpenBubbles (if you are changing from existing hardware, go to Settings -> Change Hardware).
 
 ::::
+
+### Option B. Sim / eSim Swaping Methods
+
+Sim swapping is a method which involves using an iPhone to register a number, and then using OpenBubbles normally with Mac hardware data. You can follow the same guides used for BlueBubbles. However, this method can be even more unreliable than OB.
+[All These BlueBubbles | Sim Swapping Guide](https://guide.atbluebubbles.com/ )
 
 ## DO NOT USE
 ~~[ThatMarcel's beepserv-rewrite](https://github.com/thatmarcel/beepserv-rewrite)~~

--- a/docs/pnr.md
+++ b/docs/pnr.md
@@ -8,19 +8,21 @@ The following guide contains links to third-party websites that are not affiliat
 Learn how to get your phone number working on iMessage. The app will default to sending to whatever handle is chosen in settings or setup. 
 You can also choose to skip logging in with Apple Account. This may lead to less issues in some cases.
 
-## Pre-Setup | Do this first
+## Step 1. Pre-Setup
 Make sure iMessage andFacetime is disabled on your iPhone. You also need to disable Advanced Data Protection and Contact Key Verification.
 
-## Sim / eSim Swaping Methods
+## Step 2. Activation
+
+### Option A. Sim / eSim Swaping Methods
 
 Sim swapping is a method which involves using an iPhone to register a number, and then using OpenBubbles normally with Mac hardware data. You can follow the same guides used for BlueBubbles. However, this method can be even more unreliable than OB.
 [All These BlueBubbles | Sim Swapping Guide](https://guide.atbluebubbles.com/ )
 
-## Relay Apps
+### Option B. Relay App
 Keep the device on at all times and connected to Wi-Fi in order to keep your number registered. 
 While not required, leaving the display on may improve reliability.
 
-### Method 1 - Validation Relay
+#### Method 1 - Validation Relay
 There are multiple ways to install Validation Relay, dependening on iOS version and device hardware. 
 This guide can be followed regardless of jailbreak status: 
  
@@ -37,7 +39,7 @@ Guide 1 - TrollStore
     * [ChargeLimiter](https://github.com/lich4/ChargeLimiter?tab=readme-ov-file#Introduction) to limit charge of the battery
     * [Immortalizer](https://havoc.app/package/immortalizer) to keep the relay app in the active while the screen is off.
 
-### Method 2
+#### Method 2
 
 If you are on older iOS versions (10 - 14) and jailbroken follow these steps: 
 

--- a/docs/pnr.md
+++ b/docs/pnr.md
@@ -65,8 +65,11 @@ If you are on older iOS versions (10 - 14) and jailbroken follow these steps:
 
 ### Option B. Sim / eSim Swaping Methods
 
-Sim swapping is a method which involves using an iPhone to register a number, and then using OpenBubbles normally with Mac hardware data. You can follow the same guides used for BlueBubbles. However, this method can be even more unreliable than OB.
-[All These BlueBubbles | Sim Swapping Guide](https://guide.atbluebubbles.com/ )
+**Sim swapping** is a method which involves using an iPhone to register a number, and then using OpenBubbles normally with Mac hardware data and returning your sim back into your android device.
+
+This method can be unreliable and your milage may vary.
+
+See [All These BlueBubbles | Sim Swapping Guide](https://guide.atbluebubbles.com/ )
 
 ## DO NOT USE
 ~~[ThatMarcel's beepserv-rewrite](https://github.com/thatmarcel/beepserv-rewrite)~~

--- a/docs/pnr.md
+++ b/docs/pnr.md
@@ -71,11 +71,6 @@ This method can be unreliable and your milage may vary.
 
 See [All These BlueBubbles | Sim Swapping Guide](https://guide.atbluebubbles.com/ )
 
-## DO NOT USE
-~~[ThatMarcel's beepserv-rewrite](https://github.com/thatmarcel/beepserv-rewrite)~~
-
-It is known to be **extremely unreliable** and usually only works once.
-
 ###
 **Credits** : [pypush, jjtech, Alfie,](https://discord.com/channels/1130633272595066880/1135636248019615874/1231003645529817139) [BlueBubbles Team](https://github.com/orgs/BlueBubblesApp/people), [danip](https://discord.com/channels/1130633272595066880/1135636248019615874/1231003645529817139), [cjocollin](https://www.reddit.com/r/BlueBubbles/comments/1938ock/stop_using_old_methods_heres_a_new_one/) and [Copperboy100](https://github.com/TaeHagen)
 ###

--- a/docs/pnr.md
+++ b/docs/pnr.md
@@ -16,7 +16,7 @@ We recommend reading this guide thoroughly at least once before beginning any se
 Maintaining registration requires the iPhone and relay to stay online. Apple can force a re-registeration at any time, therefore **your iPhone must be online at all times** once setup has been completed. If you're iPhone or relay is offline when Apple re-registers your phone number may be deregistered.
 
 ## Step 1. Pre-Setup
-Make sure iMessage andFacetime is disabled on your iPhone. You also need to disable Advanced Data Protection and Contact Key Verification.
+Make sure iMessage and Facetime is disabled on your iPhone. You also need to disable Advanced Data Protection and Contact Key Verification.
 
 ## Step 2. Activation
 
@@ -31,21 +31,26 @@ This method installs a Relay App to communicate the iPhone's hardware info to Op
 While not required, leaving the display on may improve reliability.
 
 :::: details Method 1 - iOS 14.0 - iOS 17.0
-There are multiple ways to install Validation Relay, dependening on iOS version and device hardware. 
-This guide can be followed regardless of jailbreak status: 
- 
-Guide 1 - TrollStore
 
-1. Install TrollStore on your device (iOS 14 - iOS 17.0) - [TrollStore Guide](https://ios.cfw.guide/installing-trollstore/)
-2. If you have TestFlight installed, delete it.
-3. Sideload JJTech's - [Validation Relay App](https://github.com/JJTech0130/ValidationRelay/releases) TIPA file in TrollStore.
-4. For best results, sign out of any Apple ID on the device.
-5. Input the code from the relay app in OpenBubbles (if you are changing from existing hardware, go to Settings -> Change Hardware).
-6. Enable Keep Awake and Dim Display
-7.  Optional Steps  - If you are jailbroken you can install the following tweaks (may not be compatible with your iOS version):
-    * [AdvancedBrightnessSlider](https://havoc.app/package/advancedbright) to lower the risk of screen burn in
-    * [ChargeLimiter](https://github.com/lich4/ChargeLimiter?tab=readme-ov-file#Introduction) to limit charge of the battery
-    * [Immortalizer](https://havoc.app/package/immortalizer) to keep the relay app in the active while the screen is off.
+There are multiple ways to install the Relay App, dependening on iOS version and device hardware. This method will sideload TrollStore on your phone, which will allow you to sideload the relay app.
+
+This guide can be followed regardless of jailbreak status: 
+
+1. Install TrollStore on your device (iOS 14.0 - iOS 17.0) via the [TrollStore Guide](https://ios.cfw.guide/installing-trollstore/)
+
+* If you have TestFlight installed, delete it.
+
+2. Download JJTech's - [Validation Relay App](https://github.com/JJTech0130/ValidationRelay/releases) on your iPhone and sideload the TIPA file in TrollStore.
+
+3. Input the code from the relay app in OpenBubbles.
+* If you are changing from existing hardware, go to Settings -> Change Hardware.
+
+4. Enable Keep Awake and Dim Display
+
+If you are jailbroken you can install the following tweaks (may not be compatible with your iOS version):
+* [AdvancedBrightnessSlider](https://havoc.app/package/advancedbright) to lower the risk of screen burn in
+* [ChargeLimiter](https://github.com/lich4/ChargeLimiter?tab=readme-ov-file#Introduction) to limit charge of the battery
+* [Immortalizer](https://havoc.app/package/immortalizer) to keep the relay app in the active while the screen is off.
 
 ::::
 

--- a/docs/pnr.md
+++ b/docs/pnr.md
@@ -1,12 +1,15 @@
 
-# Phone Number Registration
-::: info
-Phone Number Registration may not be as reliable as Mac registration, and different carriers may not play nicely. OpenBubbles operates **BEST** with Mac hardware codes.
+# Phone Number Registration <Badge type="danger" text="Caution"/>
+::: warning
 
 The following guide contains links to third-party websites that are not affiliated with OpenBubbles and their contents can change at any time. Use at your own risk.
 :::
-Learn how to get your phone number working on iMessage. The app will default to sending to whatever handle is chosen in settings or setup. 
-You can also choose to skip logging in with Apple Account. This may lead to less issues in some cases.
+
+This guide will explain how to get your phone number working on iMessage.
+
+Phone Number Registration may not be as reliable as Mac registration, and different carriers may not play nicely. OpenBubbles operates **BEST** with Mac hardware info.
+
+We recommend reading this guide thoroughly at least once before beginning any setup.
 
 ## Step 1. Pre-Setup
 Make sure iMessage andFacetime is disabled on your iPhone. You also need to disable Advanced Data Protection and Contact Key Verification.
@@ -22,7 +25,7 @@ Sim swapping is a method which involves using an iPhone to register a number, an
 Keep the device on at all times and connected to Wi-Fi in order to keep your number registered. 
 While not required, leaving the display on may improve reliability.
 
-:::: details Method 1 - Validation Relay
+:::: details Method 1 - iOS 14.0 - iOS 17.0
 There are multiple ways to install Validation Relay, dependening on iOS version and device hardware. 
 This guide can be followed regardless of jailbreak status: 
  
@@ -41,7 +44,7 @@ Guide 1 - TrollStore
 
 ::::
 
-:::: details Method 2
+:::: details Method 2 - iOS 10.0 - 14.0 (Jailbreak Required)
 
 If you are on older iOS versions (10 - 14) and jailbroken follow these steps: 
 

--- a/docs/pnr.md
+++ b/docs/pnr.md
@@ -22,7 +22,7 @@ Sim swapping is a method which involves using an iPhone to register a number, an
 Keep the device on at all times and connected to Wi-Fi in order to keep your number registered. 
 While not required, leaving the display on may improve reliability.
 
-#### Method 1 - Validation Relay
+:::: details Method 1 - Validation Relay
 There are multiple ways to install Validation Relay, dependening on iOS version and device hardware. 
 This guide can be followed regardless of jailbreak status: 
  
@@ -39,7 +39,9 @@ Guide 1 - TrollStore
     * [ChargeLimiter](https://github.com/lich4/ChargeLimiter?tab=readme-ov-file#Introduction) to limit charge of the battery
     * [Immortalizer](https://havoc.app/package/immortalizer) to keep the relay app in the active while the screen is off.
 
-#### Method 2
+::::
+
+:::: details Method 2
 
 If you are on older iOS versions (10 - 14) and jailbroken follow these steps: 
 
@@ -48,6 +50,8 @@ If you are on older iOS versions (10 - 14) and jailbroken follow these steps:
 3. Retrieve the relay code in /var/mobile/config.json. You can find this using an app like Filza.
 4. For best results, sign out of any Apple ID on the device.
 5. Input the code from the relay app in OpenBubbles (if you are changing from existing hardware, go to Settings -> Change Hardware).
+
+::::
 
 ## DO NOT USE
 ~~[ThatMarcel's beepserv-rewrite](https://github.com/thatmarcel/beepserv-rewrite)~~

--- a/docs/pnr.md
+++ b/docs/pnr.md
@@ -58,7 +58,9 @@ If you are jailbroken you can install the following tweaks (may not be compatibl
 
 If you are on older iOS versions (10 - 14) and jailbroken follow these steps: 
 
-1. Download Copperboy100's - [RelayServer](https://github.com/OpenBubbles/relayserver/releases). -arm is for iOS 10 - 14 (rootful), -arm64 is for iOS 15 - 16.5 (rootless)
+1. Download Copperboy100's - [RelayServer](https://github.com/OpenBubbles/relayserver/releases).
+* -arm is for iOS 10 - 14 (rootful)
+* -arm64 is for iOS 15 - 16.5 (rootless)
 2. Install RelayServer 
 3. Retrieve the relay code in /var/mobile/config.json. You can find this using an app like Filza.
 4. For best results, sign out of any Apple ID on the device.


### PR DESCRIPTION
I recently setup OpenBubbles, but I am technically skilled but I struggled following some of the instructions so thought I could rewrite them and improve the formatting.
Main changes include:

- Headings are ordinal
- Methods for Relay App collapsible
- Added explainers
- Swapped Simswap and relay, I did this because I felt the relay is more recommended than the sim-swap, so should probably go first, hence why I also added the Recommended tag.

Super keen to hear what you think!!